### PR TITLE
exclude external paths option

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,26 +3,29 @@ var _ = require( 'lodash' );
 var through = require( 'through2' );
 var builtPatterns = [];
 
-function buildRegex( templates, prefix ) {
+function buildRegex( templates, prefix, excludeExternal ) {
 	builtPatterns = templates.map( function( template ) {
 
-		var patt = template.replace( "$PREFIX$", prefix );
+		var patt = template
+      .replace( "$PREFIX$", prefix )
+      .replace( "$EXTERNAL$", excludeExternal ? "(?!\/\/)" : "" )
 		return new RegExp( patt, "gm" );
 	} );
 }
 
 module.exports = function( opt ) {
-	var options = _.extend( {
+	var options = _.extend({
 		patterns: [
-			"(React.DOM.img\\((?:.|[\\n\\r])*src:\\s*['\"](?!$PREFIX$))(\\/.*)(['\"])",
-			"(<img.*src=['\"](?!$PREFIX$))(\\/.*)(['\"].*>)",
-			"(<link.*href=['\"](?!$PREFIX$))(\\/.*)(['\"].*>)",
-			"(<script.*src=['\"](?!$PREFIX$))(\\/.*)(['\"].*>)",
-			"(url.*\\(.*['\"](?!$PREFIX$))(\\/.*)(['\"]\\))"
-		]
+			"(React.DOM.img\\((?:.|[\\n\\r])*src:\\s*['\"]$EXTERNAL$(?!$PREFIX$))(\\/.*)(['\"])",
+			"(<img.*src=['\"]$EXTERNAL$(?!$PREFIX$))(\\/.*)(['\"].*>)",
+			"(<link.*href=['\"]$EXTERNAL$(?!\/\/)(?!$PREFIX$))(\\/.*)(['\"].*>)",
+			"(<script.*src=['\"]$EXTERNAL$(?!$PREFIX$))(\\/.*)(['\"].*>)",
+			"(url.*\\(.*['\"]$EXTERNAL$(?!$PREFIX$))(\\/.*)(['\"]\\))"
+		],
+    excludeExternal: false
 	}, opt );
 
-	buildRegex( options.patterns, options.prefix );
+	buildRegex( options.patterns, options.prefix, options.excludeExternal );
 
 	function prefixAllTheThings( file, enc, cb ) {
 		if ( file._contents !== null ) {


### PR DESCRIPTION
adds an option to exclude external paths such `//cdn.js/jquery.1.14.js`. Option is `false` by default. Fixes #4 

Usage:

```
gulp.task( 'default', function() {
	gulp.src( [ 'source/*.*' ] )
		.pipe( pathPrefix( { prefix: '/analytics', excludeExternal: true } ) )
		.pipe( gulp.dest( './result' ) );
} );
```